### PR TITLE
행사 수정/추가 페이지 스타일 및 기능 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Outlet, Route, Routes } from 'react-router-dom'
+import { Route, Routes } from 'react-router-dom'
 
 import CalendarLayout from '@/components/layouts/CalendarLayout'
 import CalendarPage from '@/pages/Calendar'
@@ -16,19 +16,7 @@ import SignInPage from 'pages/SignInPage'
 import ApprovalPage from './pages/Manager/Approval'
 import ManagerEventAddEditPage from './pages/Manager/ManagerEventAddEdit'
 import ManagerDashboardPage from './pages/Manager/ManagerDashboard'
-import SideBar from './components/SideBar'
-
-const Layout = () => {
-  return (
-    <div className='grid grid-cols-cal-frame-w overflow-x-hidden'>
-      <SideBar/>
-      <div className='px-4'>
-        <Outlet />
-      </div>
-    </div>
-  )
-}
-
+import ManagerLayout from './components/layouts/ManagerLayout'
 
 function App() {
   return (
@@ -37,8 +25,11 @@ function App() {
         <Route path='/calendar/:year/:month/:day' element={<CalendarPage />} />
       </Route>
 
-      <Route path='/manager' element={<Layout />}>
-        <Route path='/manager/event' element={<ManagerEventAddEditPage />} />
+      <Route path='/manager' element={<ManagerLayout />}>
+        <Route
+          path='/manager/event/calendar/:year/:month/:day'
+          element={<ManagerEventAddEditPage />}
+        />
         <Route path='/manager/approval' element={<ApprovalPage />} />
         <Route path='/manager/dashboard' element={<ManagerDashboardPage />} />
       </Route>

--- a/src/components/AdminActionBar.tsx
+++ b/src/components/AdminActionBar.tsx
@@ -1,45 +1,51 @@
-import React, { useState } from 'react'
+import React, { useState, useMemo } from 'react'
 import SidebarMenu from './sidebar/SidebarMenu'
 import { useLocation } from 'react-router-dom'
 import { AiTwotoneCalendar } from 'react-icons/ai'
 import { AiOutlineEdit } from 'react-icons/ai'
 import { BiMessageRoundedCheck } from 'react-icons/bi'
 import { FaUserEdit } from 'react-icons/fa'
-
-const sidebarMenu = [
-  {
-    title: '행사 일정 캘린더',
-    id: 'admin-sidebar-0',
-    Icon: AiTwotoneCalendar
-  },
-  {
-    title: '행사 등록/수정',
-    id: 'admin-sidebar-1',
-    Icon: AiOutlineEdit
-  },
-  {
-    title: '신청 승인/취소',
-    id: 'admin-sidebar-2',
-    Icon: BiMessageRoundedCheck
-  },
-  {
-    title: '매니저 페이지',
-    id: 'admin-sidebar-3',
-    Icon: FaUserEdit
-  }
-]
+import { DATE_ROUTE_FORMAT } from '@/constants'
+import dayjs from 'dayjs'
 
 export default function AdminActionBar() {
   const location = useLocation()
-  // console.log('location : ', location.pathname)
-
+  const date = new Date()
+  const sidebarMenu = useMemo(
+    () => [
+      {
+        title: '행사 일정 캘린더',
+        id: 'admin-sidebar-0',
+        Icon: AiTwotoneCalendar,
+        url: `/calendar/${dayjs(date).format(DATE_ROUTE_FORMAT)}`
+      },
+      {
+        title: '행사 등록/수정',
+        id: 'admin-sidebar-1',
+        Icon: AiOutlineEdit,
+        url: `/manager/event/calendar/${dayjs(date).format(DATE_ROUTE_FORMAT)}`
+      },
+      {
+        title: '신청 승인/취소',
+        id: 'admin-sidebar-2',
+        Icon: BiMessageRoundedCheck,
+        url: '/manager/approval'
+      },
+      {
+        title: '매니저 페이지',
+        id: 'admin-sidebar-3',
+        Icon: FaUserEdit,
+        url: '/manager/dashboard'
+      }
+    ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
   let idx = 0
-  if (location.pathname.includes('apply')) idx = 2
-  if (location.pathname.includes('manager')) idx = 3
-  // params로 체크해서 sidebarMenu[0] 몇번째 인지 정하기
+  if (location.pathname.includes('/manager/event/calendar/')) idx = 1
+  if (location.pathname.includes('/manager/approval')) idx = 2
+  if (location.pathname.includes('/manager/dashboard')) idx = 3
   const [activeId, setActiveId] = useState(sidebarMenu[idx].id)
-
-  // const openEventSidebar = () => {}
 
   return (
     <div>
@@ -51,6 +57,7 @@ export default function AdminActionBar() {
             isActive={activeId === menu.id}
             onClick={(name) => setActiveId(name)}
             idx={idx}
+            url={menu.url}
           >
             <p className='flex items-center ml-4'>
               <menu.Icon className='mr-4 w-6 h-6' />

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -21,7 +21,16 @@ export default function Profile({ user }: Props) {
         </div>
       </div>
       <div className='flex justify-center pt-4'>
-        <Button text='로그아웃' type='red' size='md' className='font-bold w-4/5 rounded-xl' />
+        <Button
+          text='로그아웃'
+          type='red'
+          size='md'
+          className='font-bold w-4/5 rounded-xl'
+          onClick={() => {
+            alert('임시로 페이지를 새로 고쳐 로그아웃합니다.')
+            window.location.href = '/login/test'
+          }}
+        />
       </div>
     </>
   )

--- a/src/components/calendar/AddForm.tsx
+++ b/src/components/calendar/AddForm.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import AddFormInformation from './AddFormInformation'
+
+export type ScheduleAddFormData = {
+  startDate: string
+  endDate: string
+  title: string
+  description: string
+  image: string
+}
+
+type Props = {
+  date: string
+  onCancle: () => void
+  onSubmit: (schedule: ScheduleAddFormData) => void
+}
+
+export default function AddForm({ date, onCancle, onSubmit }: Props) {
+  return (
+    <section className='overflow-y-scroll h-full p-4 px-12 scrollbar-hide'>
+      <div className='h-full flex flex-col justify-between rounded-2xl'>
+        <AddFormInformation date={date} onCancle={onCancle} onSubmit={onSubmit} />
+      </div>
+    </section>
+  )
+}

--- a/src/components/calendar/AddFormInformation.tsx
+++ b/src/components/calendar/AddFormInformation.tsx
@@ -1,0 +1,156 @@
+import React, { useState } from 'react'
+import Button from '../ui/Button'
+import Banner from '../Banner'
+import { ScheduleAddFormData } from './AddForm'
+
+type Props = {
+  date: string
+  onCancle: () => void
+  onSubmit: (schedule: ScheduleAddFormData) => void
+}
+
+export default function EditFormInformation({ date, onSubmit, onCancle }: Props) {
+  const [imgSrc, setImgSrc] = useState('')
+  const [startDate, setStartDate] = useState('')
+  const [endDate, setEndDate] = useState('')
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('설명란은 아직 없습니다!')
+  //이미지 미리보기
+  const handleChangeFile = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files
+    if (files && files.length > 0) {
+      const file = files[0]
+      const reader = new FileReader()
+      reader.onloadend = () => {
+        const base64 = reader.result
+        if (base64) {
+          const str = base64?.toString()
+          if (str && str.length > 1048576 * 5) {
+            alert('이미지는 5MB이하여야합니다!')
+            return
+          }
+          setImgSrc(base64.toString())
+        }
+      }
+      reader.readAsDataURL(file)
+    }
+  }
+
+  const handleSubmit = () => {
+    // todo : validation 체크하기
+    const newSchedule = {
+      startDate,
+      endDate,
+      title,
+      description,
+      image: imgSrc
+    }
+    onSubmit(newSchedule)
+  }
+
+  return (
+    <>
+      <p className='text-red-500 font-bold'>
+        * 더미데이터는 공연 이미지가 없습니다. profile 이미지로 대체합니다.
+      </p>
+      <div className={'flex pb-4 justify-between items-end pt-4'}>
+        <span draggable={true} className='text-xl font-bold flex-1'>
+          이미지
+        </span>
+        {imgSrc ? (
+          <Banner
+            className='mr-2 p-2 bg-slate-300 rounded-xl'
+            type='side'
+            src={imgSrc}
+            alt='공연 이미지'
+          />
+        ) : (
+          <Banner
+            className='mr-2 p-2 bg-slate-300 rounded-xl'
+            type='side'
+            src='/YeonganIdolLogoOrigin.svg'
+            alt='공연 이미지'
+          />
+        )}
+        <div className='filebox mr-4'>
+          <label htmlFor='imageUploadInputLabel'>
+            <div className='bg-point px-3 min-w-[80px] text-center rounded-full text-white cursor-pointer hover:bg-rose-500 transition-all ease-in-out duration-300'>
+              업로드
+            </div>
+          </label>
+          <input
+            id='imageUploadInputLabel'
+            type='file'
+            onChange={handleChangeFile}
+            accept='image/jpeg, image/png'
+            className='upload-name'
+          />
+        </div>
+      </div>
+      <div className='flex justify-between pb-4'>
+        <span draggable={true} className='text-xl font-bold'>
+          행사 시작일
+        </span>
+        <span className='text-lg'>
+          <input
+            type='date'
+            className='bg-slate-100 px-4 rounded-xl'
+            min={date}
+            defaultValue={startDate}
+            onChange={(e) => {
+              setStartDate(e.target.value)
+              if (e.target.value > endDate) setEndDate(e.target.value)
+            }}
+          />
+        </span>
+      </div>
+      <div className='flex justify-between pb-4'>
+        <span draggable={true} className='text-xl font-bold'>
+          행사 종료일
+        </span>
+        <span className='text-lg'>
+          <input
+            type='date'
+            className='bg-slate-100 px-4 rounded-xl'
+            defaultValue={endDate}
+            min={startDate}
+            onChange={(e) => setEndDate(e.target.value)}
+          />
+        </span>
+      </div>
+      <div className='flex justify-between pb-4'>
+        <span draggable={true} className='text-xl font-bold'>
+          행사명
+        </span>
+        <input
+          className='bg-slate-100 p-2 min-w-[300px] max-w-[300px] rounded-xl'
+          defaultValue={title}
+          placeholder='행사명을 입력해주세요'
+          onChange={(e) => setTitle(e.target.value)}
+        />
+      </div>
+      <div className='flex justify-between pb-4'>
+        <span draggable={true} className='text-xl font-bold'>
+          행사 설명
+        </span>
+        <textarea
+          className='bg-slate-100 p-2 min-w-[300px] max-w-[300px] rounded-xl'
+          rows={3}
+          defaultValue={description}
+          placeholder='행사 설명을 입력해주세요'
+          onChange={(e) => setDescription(e.target.value)}
+        />
+      </div>
+      <div className='flex justify-around py-4'>
+        <Button text='추가합니다!' size='lg' className='w-3/12 font-bold' onClick={handleSubmit} />
+        <Button
+          text='취소!'
+          type='red'
+          size='lg'
+          className='w-3/12 font-bold'
+          onClick={() => onCancle()}
+        />
+      </div>
+    </>
+  )
+}

--- a/src/components/calendar/CalendarAction.tsx
+++ b/src/components/calendar/CalendarAction.tsx
@@ -2,15 +2,29 @@ import { ProviderScheduleWithPos } from '@/utils/calendar'
 import React from 'react'
 import ReserveForm from './ReserveForm'
 import { useNavigate } from 'react-router-dom'
+import EditForm from './EditForm'
+import AddForm, { ScheduleAddFormData } from './AddForm'
 
 type Props = {
   type: 'add' | 'edit' | 'reserve'
   user: 'admin' | 'fan'
   schedule?: ProviderScheduleWithPos
-  onCancle?: () => void
-  onReserve?: (schedule: ProviderScheduleWithPos, selectedDate: string) => void
+  date: string
+  onCancle: () => void
+  onReserve: (schedule: ProviderScheduleWithPos, selectedDate: string) => void
+  onEdit: (schedule: ProviderScheduleWithPos) => void
+  onSubmit: (schedule: ScheduleAddFormData) => void
 }
-export default function CalendarAction({ type, user, schedule, onCancle, onReserve }: Props) {
+export default function CalendarAction({
+  type,
+  user,
+  schedule,
+  date,
+  onCancle,
+  onReserve,
+  onEdit,
+  onSubmit
+}: Props) {
   const nativate = useNavigate()
   if (type === 'reserve' || type === 'edit') {
     if (!schedule) {
@@ -23,15 +37,14 @@ export default function CalendarAction({ type, user, schedule, onCancle, onReser
 
   return (
     <>
-      {type === 'add' && user == 'admin' && <div>add</div>}
-      {type === 'edit' && user == 'admin' && <div>edit</div>}
+      {type === 'add' && user == 'admin' && (
+        <AddForm onCancle={onCancle} onSubmit={onSubmit} date={date} />
+      )}
+      {type === 'edit' && user == 'admin' && (
+        <EditForm onCancle={onCancle} onEdit={onEdit} schedule={schedule!} />
+      )}
       {type === 'reserve' && (
-        <ReserveForm
-          onCancle={() => onCancle && onCancle()}
-          onReserve={(...args) => onReserve && onReserve(...args)}
-          schedule={schedule!}
-          user={user}
-        />
+        <ReserveForm onCancle={onCancle} onReserve={onReserve} schedule={schedule!} user={user} />
       )}
     </>
   )

--- a/src/components/calendar/CalendarAction.tsx
+++ b/src/components/calendar/CalendarAction.tsx
@@ -5,11 +5,12 @@ import { useNavigate } from 'react-router-dom'
 
 type Props = {
   type: 'add' | 'edit' | 'reserve'
+  user: 'admin' | 'fan'
   schedule?: ProviderScheduleWithPos
   onCancle?: () => void
   onReserve?: (schedule: ProviderScheduleWithPos, selectedDate: string) => void
 }
-export default function CalendarAction({ type, schedule, onCancle, onReserve }: Props) {
+export default function CalendarAction({ type, user, schedule, onCancle, onReserve }: Props) {
   const nativate = useNavigate()
   if (type === 'reserve' || type === 'edit') {
     if (!schedule) {
@@ -22,13 +23,14 @@ export default function CalendarAction({ type, schedule, onCancle, onReserve }: 
 
   return (
     <>
-      {type === 'add' && <div>add</div>}
-      {type === 'edit' && <div>edit</div>}
+      {type === 'add' && user == 'admin' && <div>add</div>}
+      {type === 'edit' && user == 'admin' && <div>edit</div>}
       {type === 'reserve' && (
         <ReserveForm
           onCancle={() => onCancle && onCancle()}
           onReserve={(...args) => onReserve && onReserve(...args)}
           schedule={schedule!}
+          user={user}
         />
       )}
     </>

--- a/src/components/calendar/CalendarFrame.tsx
+++ b/src/components/calendar/CalendarFrame.tsx
@@ -17,7 +17,7 @@ export default function CalendarFrame() {
             데이터를 가져오고 있습니다!
           </div>
           <CheerUpLoading />
-          <span className='aanimate-ping absolute inline-flex h-full w-full rounded-full bg-purple-100  opacity-10' />
+          <span className='aanimate-ping absolute inline-flex h-full w-full rounded-full bg-purple-100 opacity-10' />
           {/* <span className='relative inline-flex rounded-full h-3 w-3 bg-orange-500 ' /> */}
         </div>
       )}

--- a/src/components/calendar/CalendarModal.tsx
+++ b/src/components/calendar/CalendarModal.tsx
@@ -3,6 +3,7 @@ import { CgClose } from 'react-icons/cg'
 
 type Props = {
   children?: React.ReactNode
+
   onClose: () => void
 }
 export default function CalendarModal({ onClose, children }: Props) {

--- a/src/components/calendar/CalendarSwiper.tsx
+++ b/src/components/calendar/CalendarSwiper.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import dayjs from 'dayjs'
 
 import useSchedule from '@/hooks/schedule'
@@ -11,6 +11,7 @@ import HighlightInformation from '@/components/calendar/HighlightInformation'
 import ArrowButton, { DirectionType } from '@/components/ui/ArrowButton'
 
 export default function CalendarSwiper() {
+  const location = useLocation()
   const { isFetching } = useSchedule()
   const { year, month } = useSchedule()
   const navigate = useNavigate()
@@ -20,11 +21,17 @@ export default function CalendarSwiper() {
     (direction: DirectionType) => {
       //  todo 비정상적 주소 이동 어떻게 처리할지 정하기
       if (!year || !month) return alert('비정상적인 접근입니다.')
-      const path = swipeCalendar(direction, year, month)
+
+      const route = location.pathname.split(`/${year}`)[0]
+      const path = swipeCalendar(direction, {
+        year,
+        month,
+        path: route
+      })
       navigate(path)
       appendSwipeAnimation(CALENDAR_TAG_ID, direction)
     },
-    [navigate, year, month]
+    [navigate, year, month, location.pathname]
   )
 
   // * 오늘로 이동합니다.

--- a/src/components/calendar/Daily.tsx
+++ b/src/components/calendar/Daily.tsx
@@ -12,6 +12,7 @@ import CalendarAction from './CalendarAction'
 import { DATE_FORMAT } from '@/constants'
 import useUser from '@/hooks/user'
 import { useLocation } from 'react-router-dom'
+import { ScheduleAddFormData } from './AddForm'
 
 type Props = {
   daily: string[]
@@ -19,54 +20,79 @@ type Props = {
 export default function Daily({ daily }: Props) {
   const { getUserInfo } = useUser()
   const user = getUserInfo()
-  const location = useLocation()
+  const { pathname } = useLocation()
   const [openPortal, setOpenPortal] = useState(false)
   const [targetSchedule, setTargetSchedule] = useState({} as ProviderScheduleWithPos)
   const [openMoreModal, setOpenMoreModal] = useState(false)
   const [targetDate, setTargetDate] = useState('')
   const { width, resize, setWidth } = useResize('.ceil')
   const [isAdmin] = useState(user.role === 'ADMIN' ? true : false)
+  const [portalType, setPortalType] = useState<'edit' | 'reserve' | 'add'>('reserve')
 
   // * 행사 등록/수정 페이지 + 어드민일 경우 자신이 등록한 스케줄만 가져옵니다.
-  const adminId =
-    isAdmin && location.pathname.includes('manager/event/calendar') ? user.id : undefined
+  const adminId = isAdmin && pathname.includes('manager/event/calendar') ? user.id : undefined
   const { month, schedule, isFetching } = useSchedule(adminId)
 
   const today = dayjs(new Date()).format(DATE_FORMAT)
 
+  // * 더보기 버튼 클릭시 모달창을 띄웁니다.
   const handleViewMore = useCallback((date: string) => {
     if (!document.getElementById(`monthly-${date}`)) return
     setTargetDate(date)
     setOpenMoreModal(true)
   }, [])
 
-  const handleSchedule = useCallback((schedule: ProviderScheduleWithPos) => {
-    setTargetSchedule(schedule)
-    setOpenPortal(true)
-  }, [])
+  // * /manager 페이지라면 수정 모달을 띄우고, /calendar 페이지라면 예약 모달을 띄웁니다.
+  const handleSchedule = useCallback(
+    (schedule: ProviderScheduleWithPos) => {
+      setTargetSchedule(schedule)
+      setPortalType(pathname.includes('manager/event/calendar') ? 'edit' : 'reserve')
+      setOpenPortal(true)
+    },
+    [pathname]
+  )
 
+  // * 예약 모달에서 예약 버튼을 누르면 실행됩니다.
   const handleReserve = (schedule: ProviderScheduleWithPos, selectedDate: string) => {
     alert(`${schedule.title} 공연을 ${selectedDate}에 예약 하셨습니다.`)
     setOpenPortal(false)
   }
 
+  // * 더보기 모달창을 닫습니다.
   const setCloseMoreModal = useCallback(() => {
     setOpenMoreModal(false)
     setTargetDate('')
   }, [])
 
+  // * 모달창을 닫습니다.
   const setClosePortal = useCallback(() => {
     setOpenPortal(false)
   }, [])
 
+  // * 수정 모달에서 수정 버튼을 누르면 실행됩니다.
+  const handleEdit = (schedule: ProviderScheduleWithPos) => {
+    alert(`${schedule.title} 공연을 ${schedule.startDate} ~ ${schedule.endDate}로 수정 하셨습니다.`)
+    setOpenPortal(false)
+  }
+
+  // * 공연 추가 모달에서 새로운 공연을 추가하면 실행됩니다.
+  const handleSubmitSchedule = (schedule: ScheduleAddFormData) => {
+    alert(
+      schedule.title +
+        ' 공연을 ' +
+        schedule.startDate +
+        ' ~ ' +
+        schedule.endDate +
+        '로 등록 하셨습니다.'
+    )
+    setOpenPortal(false)
+  }
+
+  // * 스케줄이 변경되면 width를 다시 계산합니다.
   useEffect(() => {
     setWidth(() => 0)
     // prettier-ignore
-    if (!isFetching) {
-      setTimeout(() => { resize()}, 100)
-      // ? 이 로직이 필요할까?
-      // setisAdmin(user.role === 'ADMIN' ? true : false)
-    }
+    if (!isFetching) {  setTimeout(() => { resize()}, 100) }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isFetching])
 
@@ -78,12 +104,23 @@ export default function Daily({ daily }: Props) {
         let textColor = today === dayjs(date).format(DATE_FORMAT) ? 'text-point' : 'text-main'
         if (disable) textColor += ' opacity-20'
         return (
-          <div key={'daily' + date} className={`ceil ${getBgStyle(date)}`}>
-            <div id={`monthly-${date}`} />
-            <div className={`relative ${textColor}`}>
-              <div className={'pl-2 font-bold'}>
+          <div
+            key={'daily' + date}
+            className={`ceil ${getBgStyle(date)}`}
+            onClick={(e) => {
+              if (!isAdmin) return
+              if (!(e.target as HTMLElement).querySelector('.daily-ceil')) return
+              if (!pathname.includes('manager/event/calendar')) return
+              setTargetDate(date)
+              setPortalType('add')
+              setOpenPortal(true)
+            }}
+          >
+            {/* <div className='h-full hover:bg-[rgba(0,0,0,0.1)] transition-all ease-in-out duration-150' /> */}
+            <div id={`monthly-${date}`} className={`h-full relative ${textColor}`}>
+              <span className='pl-2 font-bold'>
                 {dayjs(date).date() / 10 < 1 ? '0' + dayjs(date).date() : dayjs(date).date()}
-              </div>
+              </span>
               {providerSchedule?.map((s, i) => {
                 if (disable || i > 1) return null
                 return (
@@ -116,11 +153,14 @@ export default function Daily({ daily }: Props) {
         <ModalPortal>
           <CalendarModal onClose={setClosePortal}>
             <CalendarAction
-              type='reserve'
+              type={portalType}
               user={isAdmin ? 'admin' : 'fan'}
               schedule={targetSchedule}
+              date={targetDate}
               onCancle={setClosePortal}
               onReserve={handleReserve}
+              onEdit={handleEdit}
+              onSubmit={handleSubmitSchedule}
             />
           </CalendarModal>
         </ModalPortal>
@@ -134,5 +174,6 @@ function getBgStyle(date: string) {
   if (dayjs(date).format('ddd') === '일' || dayjs(date).format('ddd') === '토') {
     bgStyle = 'bg-blue-100'
   }
+  bgStyle += ' cursor-pointer'
   return bgStyle
 }

--- a/src/components/calendar/Daily.tsx
+++ b/src/components/calendar/Daily.tsx
@@ -117,6 +117,7 @@ export default function Daily({ daily }: Props) {
           <CalendarModal onClose={setClosePortal}>
             <CalendarAction
               type='reserve'
+              user={isAdmin ? 'admin' : 'fan'}
               schedule={targetSchedule}
               onCancle={setClosePortal}
               onReserve={handleReserve}

--- a/src/components/calendar/DailyDetail.tsx
+++ b/src/components/calendar/DailyDetail.tsx
@@ -23,7 +23,7 @@ export default function DailyDetail({ date }: Props) {
   }, [schedule, isFetching])
 
   const handleClickSchedule = (schedule: ProviderScheduleWithPos) => {
-    console.info('handleClickSchedule  : ', schedule)
+    alert('handleClickSchedule more에서 더보기 기능 처리 필요 : ' + schedule.title)
   }
 
   return (

--- a/src/components/calendar/DailySchedule.tsx
+++ b/src/components/calendar/DailySchedule.tsx
@@ -15,42 +15,39 @@ export default function DailySchedule({ schedule, ceilWidth, onClickSchedule }: 
   let ceils = dayjs(schedule.endDate).diff(dayjs(schedule.startDate), 'day') + 1
   if (schedule.pos === 'start-end') ceils = 1
   return (
-    <div className={'relative my-1 text-white text-[0.8rem]'}>
-      <div>
-        {schedule.pos.includes('start') ? (
-          <>
-            <span className='whitespace-nowrap invisible'>{schedule.title}</span>
-            <button
-              className={`
-              flex justify-start items-center absolute left-0 top-0 text-start whitespace-nowrap z-30 cursor-pointer
-               transition-all ease-in-out duration-200
+    <div className={'relative my-1 text-white text-[0.8rem] daily-ceil'}>
+      {schedule.pos.includes('start') ? (
+        <>
+          <span className='whitespace-nowrap invisible'>{schedule.title}</span>
+          <button
+            className={`
+              flex justify-start items-center absolute left-0 top-0 text-start whitespace-nowrap z-50 cursor-pointer transition-all ease-in-out duration-700
               `}
-              style={{
-                minWidth: `${ceilWidth * ceils}px`,
-                maxWidth: `${ceilWidth * ceils}px`
-              }}
-              onClick={() => {
-                onClickSchedule(schedule)
-              }}
+            style={{
+              minWidth: `${ceilWidth * ceils}px`,
+              maxWidth: `${ceilWidth * ceils}px`
+            }}
+            onClick={() => {
+              onClickSchedule(schedule)
+            }}
+          >
+            <img
+              src={schedule.profileImage}
+              alt={schedule.fullName}
+              className='absolute w-5 h-5 z-40'
+            />
+            <div
+              className={`w-full ${
+                schedule.pos === 'start-end' ? 'rounded-l-xl' : 'rounded-xl'
+              } min-w-[100px] cursor-pointer bg-main hover:bg-[#4619a5] pl-8 transition-all ease-in-out z-30 duration-200 overflow-hidden`}
             >
-              <img
-                src={schedule.profileImage}
-                alt={schedule.fullName}
-                className='absolute w-5 h-5'
-              />
-              <div
-                className={`w-full ${
-                  schedule.pos === 'start-end' ? 'rounded-l-xl' : 'rounded-xl'
-                } min-w-[100px] cursor-pointer bg-main hover:bg-[#4619a5] pl-8 transition-all ease-in-out duration-1000 overflow-hidden`}
-              >
-                {schedule.title}
-              </div>
-            </button>
-          </>
-        ) : (
-          <div className='whitespace-nowrap invisible'>{schedule.title}</div>
-        )}
-      </div>
+              {schedule.title}
+            </div>
+          </button>
+        </>
+      ) : (
+        <div className='whitespace-nowrap invisible'>{schedule.title}</div>
+      )}
     </div>
   )
 }

--- a/src/components/calendar/EditForm.tsx
+++ b/src/components/calendar/EditForm.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { ProviderScheduleWithPos } from '@/utils/calendar'
+
+import EditFormInformation from './EditFormInformation'
+
+type Props = {
+  schedule: ProviderScheduleWithPos
+
+  onCancle: () => void
+  onEdit: (schedule: ProviderScheduleWithPos) => void
+}
+
+export default function EditForm({ schedule, onCancle, onEdit }: Props) {
+  return (
+    <section className='overflow-y-scroll h-full p-4 px-12 scrollbar-hide'>
+      <div className='h-full flex flex-col justify-between rounded-2xl'>
+        <EditFormInformation schedule={schedule} onCancle={onCancle} onEdit={onEdit} />
+      </div>
+    </section>
+  )
+}

--- a/src/components/calendar/EditFormInformation.tsx
+++ b/src/components/calendar/EditFormInformation.tsx
@@ -1,0 +1,166 @@
+import { ProviderScheduleWithPos } from '@/utils/calendar'
+import React, { useState } from 'react'
+import Banner from '../Banner'
+import dayjs from 'dayjs'
+import { DATE_FORMAT } from '@/constants'
+import Button from '../ui/Button'
+
+type Props = {
+  schedule: ProviderScheduleWithPos
+  onCancle: () => void
+  onEdit: (schedule: ProviderScheduleWithPos) => unknown
+}
+
+export default function EditFormInformation({ schedule, onEdit, onCancle }: Props) {
+  const [imgSrc, setImgSrc] = useState('')
+  const date = dayjs(new Date()).format(DATE_FORMAT)
+  const [startDate, setStartDate] = useState('')
+  const [endDate, setEndDate] = useState('')
+  const [title, setTitle] = useState(schedule.title)
+  const [description, setDescription] = useState('설명란은 아직 없습니다!')
+  //이미지 미리보기
+  const handleChangeFile = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files
+    if (files && files.length > 0) {
+      const file = files[0]
+      const reader = new FileReader()
+      reader.onloadend = () => {
+        const base64 = reader.result
+        if (base64) {
+          const str = base64?.toString()
+          if (str && str.length > 1048576 * 5) {
+            alert('이미지는 5MB이하여야합니다!')
+            return
+          }
+          setImgSrc(base64.toString())
+        }
+      }
+      reader.readAsDataURL(file)
+    }
+  }
+
+  const handleSubmit = () => {
+    // todo : validation 체크하기
+    const newSchedule = {
+      ...schedule,
+      startDate,
+      endDate,
+      title,
+      description,
+      imgSrc
+    }
+    onEdit(newSchedule)
+  }
+
+  return (
+    <>
+      <p className='text-red-500 font-bold'>
+        * 더미데이터는 공연 이미지가 없습니다. profile 이미지로 대체합니다.
+      </p>
+      <div className={'flex pb-4 justify-between items-end pt-4'}>
+        <span draggable={true} className='text-xl font-bold flex-1'>
+          이미지
+        </span>
+        {imgSrc ? (
+          <Banner
+            className='mr-2 p-2 bg-slate-300 rounded-xl'
+            type='side'
+            src={imgSrc}
+            alt='공연 이미지'
+          />
+        ) : (
+          <Banner
+            className='mr-2 p-2 bg-slate-300 rounded-xl'
+            type='side'
+            src='/YeonganIdolLogoOrigin.svg'
+            alt='공연 이미지'
+          />
+        )}
+        <div className='filebox mr-4'>
+          <label htmlFor='imageUploadInputLabel'>
+            <div className='bg-point px-3 min-w-[80px] text-center rounded-full text-white cursor-pointer hover:bg-rose-500 transition-all ease-in-out duration-300'>
+              업로드
+            </div>
+          </label>
+          <input
+            id='imageUploadInputLabel'
+            type='file'
+            onChange={handleChangeFile}
+            accept='image/jpeg, image/png'
+            className='upload-name'
+          />
+        </div>
+      </div>
+      <div className={'flex pb-4 justify-between pt-4'}>
+        <span draggable={true} className='text-xl font-bold'>
+          행사 날짜
+        </span>
+        <span className='text-lg font-bold'>
+          {schedule.startDate} ~ {schedule.endDate}
+        </span>
+      </div>
+      <div className='flex justify-between pb-4'>
+        <span draggable={true} className='text-xl font-bold'>
+          행사 시작일
+        </span>
+        <span className='text-lg'>
+          <input
+            type='date'
+            className='bg-slate-100 px-4 rounded-xl'
+            min={date}
+            defaultValue={startDate}
+            onChange={(e) => {
+              setStartDate(e.target.value)
+              if (e.target.value > endDate) setEndDate(e.target.value)
+            }}
+          />
+        </span>
+      </div>
+      <div className='flex justify-between pb-4'>
+        <span draggable={true} className='text-xl font-bold'>
+          행사 종료일
+        </span>
+        <span className='text-lg'>
+          <input
+            type='date'
+            className='bg-slate-100 px-4 rounded-xl'
+            defaultValue={endDate}
+            min={startDate}
+            onChange={(e) => setEndDate(e.target.value)}
+          />
+        </span>
+      </div>
+      <div className='flex justify-between pb-4'>
+        <span draggable={true} className='text-xl font-bold'>
+          행사명
+        </span>
+        <input
+          className='bg-slate-100 p-2 min-w-[300px] max-w-[300px] rounded-xl'
+          defaultValue={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+      </div>
+      <div className='flex justify-between pb-4'>
+        <span draggable={true} className='text-xl font-bold'>
+          행사 설명
+        </span>
+        <textarea
+          className='bg-slate-100 p-2 min-w-[300px] max-w-[300px] rounded-xl'
+          rows={3}
+          defaultValue={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+      </div>
+      <div className='flex justify-around py-4'>
+        <Button text='수정합니다!' size='lg' className='w-3/12 font-bold' onClick={handleSubmit} />
+        <Button
+          text='취소!'
+          type='red'
+          size='lg'
+          className='w-3/12 font-bold'
+          onClick={() => onCancle()}
+        />
+      </div>
+    </>
+  )
+}

--- a/src/components/calendar/MonthlyCalendar.tsx
+++ b/src/components/calendar/MonthlyCalendar.tsx
@@ -6,7 +6,7 @@ import useSchedule from '@/hooks/schedule'
 import Weeks from '@/components/calendar/Weeks'
 import Daily from '@/components/calendar/Daily'
 
-export default function Month() {
+export default function MonthlyCalendar() {
   const { year, month } = useSchedule()
 
   // todo dayjs(date).dayjsInMonth로 달력 마지막 날 보고 인덱스 row를 6개 | 5개로 조정하기

--- a/src/components/calendar/ReserveForm.tsx
+++ b/src/components/calendar/ReserveForm.tsx
@@ -6,11 +6,12 @@ import Button from '../ui/Button'
 
 type Props = {
   schedule: ProviderScheduleWithPos
+  user: 'admin' | 'fan'
   onCancle: () => void
   onReserve: (schedule: ProviderScheduleWithPos, selectedDate: string) => void
 }
 
-export default function ReserveForm({ schedule, onCancle, onReserve }: Props) {
+export default function ReserveForm({ schedule, onCancle, onReserve, user }: Props) {
   const [selectedDate, setSelectedDate] = useState('')
   return (
     <section className='overflow-hidden h-full p-4 px-12'>
@@ -28,23 +29,29 @@ export default function ReserveForm({ schedule, onCancle, onReserve }: Props) {
           />
         </div>
         <div className='flex justify-around py-4'>
-          <Button
-            disabled={!selectedDate}
-            text='신청하기'
-            size='lg'
-            className='w-3/12 font-bold'
-            onClick={() => {
-              if (!selectedDate) return alert('날짜를 선택해주세요.')
-              onReserve(schedule, selectedDate)
-            }}
-          />
-          <Button
-            text='취소'
-            type='red'
-            size='lg'
-            className='w-3/12 font-bold'
-            onClick={() => onCancle()}
-          />
+          {user === 'fan' ? (
+            <>
+              <Button
+                disabled={!selectedDate}
+                text='신청하기'
+                size='lg'
+                className='w-3/12 font-bold'
+                onClick={() => {
+                  if (!selectedDate) return alert('날짜를 선택해주세요.')
+                  onReserve(schedule, selectedDate)
+                }}
+              />
+              <Button
+                text='취소'
+                type='red'
+                size='lg'
+                className='w-3/12 font-bold'
+                onClick={() => onCancle()}
+              />
+            </>
+          ) : (
+            <div className='text-2xl font-bold text-point'>매니저는 예약할 수 없습니다!</div>
+          )}
         </div>
       </div>
     </section>

--- a/src/components/calendar/ReserveFormInfomation.tsx
+++ b/src/components/calendar/ReserveFormInfomation.tsx
@@ -12,6 +12,7 @@ type Props = {
 export default function ReserveFormInfomation({ schedule, onChageDate }: Props) {
   const date = new Date()
 
+  // todo 이미 지난 날짜는 예약 불가능하게 하기
   const itemStyle = 'flex justify-between items-center pb-8'
   return (
     <ul>
@@ -30,7 +31,11 @@ export default function ReserveFormInfomation({ schedule, onChageDate }: Props) 
         <span className='text-lg font-bold'>
           {schedule.startDate < dayjs(date).format(DATE_FORMAT) ? (
             <div className='flex text-slate-500'>
-              <span>예약 불가</span>
+              <span>
+                {schedule.endDate > dayjs(date).format(DATE_FORMAT)
+                  ? '진행 중인 행사입니다!'
+                  : '이미 끝난 행사입니다!'}
+              </span>
               <FcOvertime className='ml-2 w-8 h-8' />
             </div>
           ) : (

--- a/src/components/layouts/ManagerLayout.tsx
+++ b/src/components/layouts/ManagerLayout.tsx
@@ -25,6 +25,7 @@ export default function ManagerLayout() {
     <div className='grid grid-cols-cal-frame-w overflow-x-hidden'>
       {loggedIn && <SideBar />}
       {loggedIn && <Outlet />}
+      <div id='portal' />
     </div>
   )
 }

--- a/src/components/layouts/ManagerLayout.tsx
+++ b/src/components/layouts/ManagerLayout.tsx
@@ -1,0 +1,30 @@
+import useUser from '@/hooks/user'
+import React, { useEffect } from 'react'
+import { Outlet, useNavigate } from 'react-router-dom'
+import SideBar from '../SideBar'
+
+export default function ManagerLayout() {
+  const navigate = useNavigate()
+  const { getUserInfo, loggedIn } = useUser()
+
+  useEffect(() => {
+    if (!loggedIn) {
+      alert('로그인 후 이용해주세요')
+      navigate('/login/test')
+      return
+    }
+    const user = getUserInfo()
+    if (user.role !== 'ADMIN') {
+      alert('관리자만 접근할 수 있는 페이지 입니다!')
+      navigate('/login/test')
+      return
+    }
+  }, [getUserInfo, loggedIn, navigate])
+
+  return (
+    <div className='grid grid-cols-cal-frame-w overflow-x-hidden'>
+      {loggedIn && <SideBar />}
+      {loggedIn && <Outlet />}
+    </div>
+  )
+}

--- a/src/components/sidebar/SidebarMenu.tsx
+++ b/src/components/sidebar/SidebarMenu.tsx
@@ -1,22 +1,27 @@
 import React from 'react'
+import { Link } from 'react-router-dom'
 
 type Props = {
   children: React.ReactNode
   isActive?: boolean
   name: string
   idx: number
+  url: string
   onClick?: (name: string) => void
 }
-export default function SidebarMenu({ name, children, isActive = false, onClick }: Props) {
+export default function SidebarMenu({ name, children, isActive = false, url, onClick }: Props) {
   const style = isActive ? 'bg-white text-main rounded-l-[20px]' : 'bg-main text-white'
   return (
     <div className='relative h-[70px] bg-white font-bold' onClick={() => onClick && onClick(name)}>
       <div className={`${isActive ? 'h-[70px]' : 'h-[70px]'} w-full text-right bg-main`}>
-        <div className='relative'>
+        <div className='relative bounce-menu'>
           {isActive && <img className='absolute right-0 z-40' src='/sbtn_ac.svg' />}
-          <button className={`absolute w-[240px] h-[50px] right-0 top-[20px] z-50 ${style}`}>
+          <Link
+            to={url}
+            className={`absolute flex items-center w-[240px] h-[50px] right-0 top-[20px] z-50 ${style}`}
+          >
             {children}
-          </button>
+          </Link>
         </div>
       </div>
     </div>

--- a/src/hooks/schedule.ts
+++ b/src/hooks/schedule.ts
@@ -6,7 +6,7 @@ import dayjs from 'dayjs'
 import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
-export default function useSchedule() {
+export default function useSchedule(userId?: string) {
   const params = useParams()
   const [schedule, setSchedule] = useState<ProviderSchedule[]>([])
   const [isFetching, setIsFetching] = useState(true)
@@ -25,18 +25,23 @@ export default function useSchedule() {
     if (month === 6) scheduleData = []
     if (month === 9) scheduleData = []
 
-    scheduleData.map((s) => {
+    scheduleData = scheduleData.map((s) => {
       return {
         ...s,
         startDate: dayjs(s.startDate).format(DATE_FORMAT),
         endDate: dayjs(s.endDate).format(DATE_FORMAT)
       }
     })
+
+    if (userId) {
+      scheduleData = scheduleData.filter((s) => s.userId === userId)
+    }
+
     delay<ProviderSchedule[]>(scheduleData, 2000).then((res) => {
       setSchedule(res)
       setIsFetching(false)
     })
-  }, [year, month])
+  }, [year, month, userId])
 
   useEffect(() => {
     if (

--- a/src/index.css
+++ b/src/index.css
@@ -85,3 +85,19 @@ input[type='date']::-webkit-calendar-picker-indicator:hover {
     opacity: 1;
   }
 }
+
+.bounce-menu:hover svg {
+  animation: bounceSideBar 1s infinite;
+}
+
+@keyframes bounceSideBar {
+  0%,
+  100% {
+    transform: translateY(-4px);
+    animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+  }
+  50% {
+    transform: none;
+    animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -28,6 +28,17 @@ input[type='date']::-webkit-calendar-picker-indicator:hover {
   transform: scale(1.2);
 }
 
+.filebox input[type='file'] {
+  position: absolute;
+  width: 0;
+  height: 0;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
 .move-from-left {
   animation: moveFromLeft 0.2s ease-in-out;
   animation-fill-mode: backwards;

--- a/src/pages/Manager/ManagerEventAddEdit/index.tsx
+++ b/src/pages/Manager/ManagerEventAddEdit/index.tsx
@@ -1,13 +1,12 @@
+import Banner from '@/components/Banner'
+import CalendarFrame from '@/components/calendar/CalendarFrame'
 import React from 'react'
 
 export default function ManagerEventAddEditPage() {
   return (
-    <div>
-      행사 등록/수정
-      <br />
-      1. 행사 선택 캘린더: 나중에 작업
-      <br />
-      2. 행사 리스트 컴포넌트: 반응형 행사 등록버튼 추가
+    <div className='mb-12 min-w-[760px] max-w-[1432px] px-[1.25rem]'>
+      <Banner className='py-4' src='/newjeans_ad.png' type='top' alt='newjeans banner' />
+      <CalendarFrame />
     </div>
   )
 }

--- a/src/utils/calendar.ts
+++ b/src/utils/calendar.ts
@@ -8,26 +8,25 @@ import dayjs from 'dayjs'
  * */
 export function swipeCalendar(
   direction: DirectionType,
-  year: number,
-  month: number,
-  today?: string
+  p: { year: number; month: number; today?: string; path: string }
 ) {
+  const { month, year, today, path } = p
   // * 현재 day를 계산
   const date = new Date()
   const currentMonth = month + (direction === 'left' ? -1 : 1)
   const day = date.getMonth() + 1 === currentMonth ? date.getDate() : 1
   if (direction === 'left') {
     const prevDate = dayjs(`${year}/${month}/${today ? today : day}`).subtract(1, 'month')
-    return `/calendar/${dayjs(prevDate).format(DATE_ROUTE_FORMAT)}`
+    return `${path}/${dayjs(prevDate).format(DATE_ROUTE_FORMAT)}`
   }
   if (direction === 'right') {
-    return `/calendar/${dayjs(dayjs(`${year}/${currentMonth}/${today ? today : day}`)).format(
+    return `${path}/${dayjs(dayjs(`${year}/${currentMonth}/${today ? today : day}`)).format(
       DATE_ROUTE_FORMAT
     )}`
   }
   alert('잘못된 접근입니다.')
   //  todo 비정상적 주소 이동 어떻게 처리할지 정하기
-  return `/calendar/${year}/${month}/1`
+  return `${path}/${year}/${month}/1`
 }
 
 /**


### PR DESCRIPTION
# 요약

행사 수정/추가 페이지 스타일 및 기능을 구현했습니다.

# 주요 키워드

## 1. 레이아웃 위치 변경
App.tsx에 있던 Layout.tsx가 /components/layout/ManagerLayout.tsx 로 이동되었습니다.


## 2. 라우터 수정
/manager/event 라우터가 /manager/event/calendar/:year/:month/:day로 이동되었습니다.

## 3. 임시 로그인 훅 사용 

/components/layout/ManagerLayout.tsx에 들어가보시면 임시로 로그인이 되도록 변경했습니다.

## 4. sidebar에서 매니저, 팬 이동

로그인이 안되더라도 calendar 페이지에서 유저, 팬에 따라서 이동이 가능하도록 임시로 수정했습니다.

# 참고 

1. 어드민으로 로그인 합니다 
![화면 캡처 2023-08-02 223452](https://github.com/MINI-FASTCAMPUS5/scheduler-front/assets/73880776/63fe9e3f-ef52-4d4f-bbba-670365c97213)

2. 행사 등록/수정 페이지 이동
![화면 캡처 2023-08-02 223320](https://github.com/MINI-FASTCAMPUS5/scheduler-front/assets/73880776/fecd5a91-8c2e-4565-ac20-0fafd046e1e9)

3. 행사 편집
![화면 캡처 2023-08-02 223326](https://github.com/MINI-FASTCAMPUS5/scheduler-front/assets/73880776/23a8573c-1914-4b7a-a538-3469028047c6)

4. 행사 추가
![화면 캡처 2023-08-02 223335](https://github.com/MINI-FASTCAMPUS5/scheduler-front/assets/73880776/5de79198-3433-4003-9c95-89727dec049e)

5. 그 외 페이지 접근 (URL 주소 확인)
![화면 캡처 2023-08-02 223357](https://github.com/MINI-FASTCAMPUS5/scheduler-front/assets/73880776/77d463c3-a2c3-44e3-90cd-2ffabc6e75da)
![화면 캡처 2023-08-02 223404](https://github.com/MINI-FASTCAMPUS5/scheduler-front/assets/73880776/09041fa8-98e7-445c-a2ae-ab89ce056365)





