### PR TITLE
캘린더 페이지 API 연결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ function App() {
           />
           <Route path='/manager/approval' element={<ApprovalPage />} />
           <Route path='/manager/dashboard' element={<ManagerDashboardPage />} />
+          <Route path='/manager/edit' element={<Edit />} />
         </Route>
         <Route path='/user' element={<UserLayout />}>
           <Route path='/user/mypage' element={<MyPage />} />

--- a/src/api/schedule/admin.ts
+++ b/src/api/schedule/admin.ts
@@ -1,0 +1,39 @@
+import { ScheduleAddFormData } from '@/components/calendar/AddForm'
+import { DATE_REQEUST_FORMAT } from '@/constants'
+import dayjs from 'dayjs'
+import api from '..'
+
+export const createSchedule = async (schedule: ScheduleAddFormData, token: string) => {
+  try {
+    const formData = new FormData()
+    formData.append('file', schedule.imageFile)
+    formData.append(
+      'dto',
+      new Blob(
+        [
+          JSON.stringify({
+            title: schedule.title,
+            scheduleStart: dayjs(schedule.startDate).format(DATE_REQEUST_FORMAT),
+            scheduleEnd: dayjs(schedule.endDate).format(DATE_REQEUST_FORMAT),
+            description: schedule.description
+          })
+        ],
+        {
+          type: 'application/json'
+        }
+      )
+    )
+    await api('/admin/schedule/create', {
+      method: 'POST',
+      data: formData,
+      headers: {
+        'Content-Type': 'multipart/form-data',
+        Authorization: token
+      }
+    })
+    return true
+  } catch (err) {
+    console.error(err)
+    return false
+  }
+}

--- a/src/api/schedule/index.ts
+++ b/src/api/schedule/index.ts
@@ -28,7 +28,6 @@ export const fetchSchedule = async ({
         Authorization: token
       }
     })
-
     const schedule = res.data.schedulerAdmin
       .map((s) => {
         return {
@@ -54,14 +53,12 @@ export const fetchSchedule = async ({
       const reservedDate = dayjs(s.scheduleStart).format(DATE_FORMAT)
       return {
         id: s.id,
-        userID: s.user.id,
-        profileImage: s.user.profileImage,
-        fullName: s.user.fullName,
-        role: s.user.role,
-        sizeOfTicket: s.user.sizeOfTicket,
-        reservedDate,
+        scheduleId: s.schedulerAdmin.id,
         progress: s.progress,
-        title: s.schedulerAdmin.title // 고유 ID가 없어서 title로 schedule을 매칭합니다..
+        reservedDate,
+        user: {
+          ...s.user
+        }
       }
     })
 

--- a/src/api/schedule/index.ts
+++ b/src/api/schedule/index.ts
@@ -28,11 +28,10 @@ export const fetchSchedule = async ({
         Authorization: token
       }
     })
-    // console.log('RES:DATA : ', res.data)
     const schedule = res.data.schedulerAdmin
       .map((s) => {
         return {
-          id: s.user.id + s.createdAt, // post id PK가 안와서 임시로 만듬
+          id: s.id, // post id PK가 안와서 임시로 만듬
           userId: s.user.id,
           title: s.title,
           fullName: s.user.fullName,

--- a/src/api/schedule/index.ts
+++ b/src/api/schedule/index.ts
@@ -28,6 +28,7 @@ export const fetchSchedule = async ({
         Authorization: token
       }
     })
+
     const schedule = res.data.schedulerAdmin
       .map((s) => {
         return {
@@ -52,7 +53,7 @@ export const fetchSchedule = async ({
     const reservedList = res.data.schedulerUser.map((s) => {
       const reservedDate = dayjs(s.scheduleStart).format(DATE_FORMAT)
       return {
-        id: s.scheduleStart + s.createdAt,
+        id: s.id,
         userID: s.user.id,
         profileImage: s.user.profileImage,
         fullName: s.user.fullName,

--- a/src/api/schedule/index.ts
+++ b/src/api/schedule/index.ts
@@ -28,6 +28,7 @@ export const fetchSchedule = async ({
         Authorization: token
       }
     })
+    // console.log('RES:DATA : ', res.data)
     const schedule = res.data.schedulerAdmin
       .map((s) => {
         return {

--- a/src/api/schedule/user.ts
+++ b/src/api/schedule/user.ts
@@ -2,7 +2,7 @@ import api from '@/api'
 
 export const addSchedule = async (adminId: string, selectDate: string, cookie: string) => {
   try {
-    const res = await api({
+    await api({
       url: `/user/schedule/create?schedulerAdminId=${adminId}`,
       method: 'POST',
       headers: {
@@ -12,10 +12,9 @@ export const addSchedule = async (adminId: string, selectDate: string, cookie: s
         scheduleStart: selectDate
       }
     })
-    console.info(res)
     return true
   } catch (err) {
-    console.info(err)
+    console.error(err)
     return false
   }
 }

--- a/src/api/user/mypage.ts
+++ b/src/api/user/mypage.ts
@@ -6,27 +6,31 @@ export type SchedulerRoleUserList = {
   progress: 'WAITING' | 'ACCEPT' | 'REFUSE'
 }
 export type TicketListResponse = {
-  createdAt: string
-  email: string
-  fullName: string
-  profileImage: string
+  getUserInfoDTO: {
+    id: number
+    email: string
+    fullName: string
+    profileImage: string
+    role: 'USER' | 'ADMIN'
+    sizeOfTicket: number
+    usedTicket: number
+  }
   schedulerRoleUserList: SchedulerRoleUserList[]
-  sizeOfTicket: number
-  usedTicket: number
 }
 export const getMyTicketList = async (cookie: string): Promise<TicketListResponse | null> => {
   try {
-    const { data } = await api({
+    const res = await api({
       url: '/mypage?role=USER',
       method: 'GET',
       headers: {
         Authorization: cookie
       }
     })
-    if (data.data) return data.data
+
+    if (res.data.data) return res.data.data
     return null
   } catch (error) {
-    console.error(error)
+    console.info(error)
     return null
   }
 }

--- a/src/components/AdminActionBar.tsx
+++ b/src/components/AdminActionBar.tsx
@@ -36,12 +36,6 @@ export default function AdminActionBar() {
         id: 'admin-sidebar-3',
         Icon: FaUserEdit,
         url: '/manager/dashboard'
-      },
-      {
-        title: '임시 스케줄 추가 페이지 (제거예정)',
-        id: 'admin-sidebar-4',
-        Icon: FaUserEdit,
-        url: '/calendar/schedule'
       }
     ],
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/SideBar.tsx
+++ b/src/components/SideBar.tsx
@@ -15,7 +15,7 @@ export default function SideBar() {
 
   return (
     <aside
-      className={`sticky top-2 left-2 mb-2 flex flex-col min-w-[300px] max-w-[300px] max-h-[calc(100vh_-_1rem)] min-h-[860px] pt-4 rounded-[20px] bg-main z-[60]
+      className={`sticky mt-2 left-2 mb-2 flex flex-col min-w-[300px] max-w-[300px] max-h-[calc(100vh_-_1rem)] min-h-[860px] pt-4 rounded-[20px] bg-main z-[60]
       transition-all ease-out duration-75`}
     >
       <div>

--- a/src/components/calendar/AddForm.tsx
+++ b/src/components/calendar/AddForm.tsx
@@ -6,7 +6,7 @@ export type ScheduleAddFormData = {
   endDate: string
   title: string
   description: string
-  image: string
+  imageFile: File
 }
 
 type Props = {
@@ -14,7 +14,6 @@ type Props = {
   onCancle: () => void
   onSubmit: (schedule: ScheduleAddFormData) => void
 }
-
 export default function AddForm({ date, onCancle, onSubmit }: Props) {
   return (
     <section className='overflow-y-scroll h-full p-4 px-12 scrollbar-hide'>

--- a/src/components/calendar/AddFormInformation.tsx
+++ b/src/components/calendar/AddFormInformation.tsx
@@ -10,16 +10,18 @@ type Props = {
 }
 
 export default function EditFormInformation({ date, onSubmit, onCancle }: Props) {
+  const [file, setFile] = useState<File>()
   const [imgSrc, setImgSrc] = useState('')
   const [startDate, setStartDate] = useState('')
   const [endDate, setEndDate] = useState('')
   const [title, setTitle] = useState('')
-  const [description, setDescription] = useState('설명란은 아직 없습니다!')
+  const [description, setDescription] = useState('')
   //이미지 미리보기
   const handleChangeFile = (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files
     if (files && files.length > 0) {
       const file = files[0]
+      setFile(file)
       const reader = new FileReader()
       reader.onloadend = () => {
         const base64 = reader.result
@@ -38,12 +40,13 @@ export default function EditFormInformation({ date, onSubmit, onCancle }: Props)
 
   const handleSubmit = () => {
     // todo : validation 체크하기
+    if (!file) return
     const newSchedule = {
       startDate,
       endDate,
       title,
       description,
-      image: imgSrc
+      imageFile: file
     }
     onSubmit(newSchedule)
   }
@@ -134,7 +137,7 @@ export default function EditFormInformation({ date, onSubmit, onCancle }: Props)
           className='bg-slate-100 p-2 min-w-[300px] max-w-[300px] rounded-xl'
           rows={3}
           defaultValue={description}
-          placeholder='행사 설명을 입력해주세요'
+          placeholder='행사 내용을 입력해주세요'
           onChange={(e) => setDescription(e.target.value)}
         />
       </div>

--- a/src/components/calendar/AddFormInformation.tsx
+++ b/src/components/calendar/AddFormInformation.tsx
@@ -50,9 +50,6 @@ export default function EditFormInformation({ date, onSubmit, onCancle }: Props)
 
   return (
     <>
-      <p className='text-red-500 font-bold'>
-        * 더미데이터는 공연 이미지가 없습니다. profile 이미지로 대체합니다.
-      </p>
       <div className={'flex pb-4 justify-between items-end pt-4'}>
         <span draggable={true} className='text-xl font-bold flex-1'>
           이미지

--- a/src/components/calendar/CalendarAction.tsx
+++ b/src/components/calendar/CalendarAction.tsx
@@ -54,7 +54,7 @@ export default function CalendarAction({
   const handleReserve = (schedule: ProviderScheduleWithPos, selectDate: string) => {
     reserveMutation
       .mutateAsync({
-        adminId: schedule.userId,
+        adminId: schedule.id,
         selectDate: dayjs(selectDate).format(DATE_REQEUST_FORMAT)
       })
       .then((isReflected) => {
@@ -75,6 +75,7 @@ export default function CalendarAction({
   ) => {
     const formData = new FormData()
     if (schedule.imgFile) formData.append('file', schedule.imgFile as Blob)
+
     formData.append(
       'dto',
       new Blob(
@@ -91,7 +92,6 @@ export default function CalendarAction({
         }
       )
     )
-
     api(`/admin/schedule/update/${schedule.id}`, {
       method: 'POST',
       data: formData,

--- a/src/components/calendar/CalendarAction.tsx
+++ b/src/components/calendar/CalendarAction.tsx
@@ -54,7 +54,7 @@ export default function CalendarAction({
   const handleReserve = (schedule: ProviderScheduleWithPos, selectDate: string) => {
     reserveMutation
       .mutateAsync({
-        adminId: schedule.userId,
+        adminId: schedule.id,
         selectDate: dayjs(selectDate).format(DATE_REQEUST_FORMAT)
       })
       .then((isReflected) => {

--- a/src/components/calendar/CalendarAction.tsx
+++ b/src/components/calendar/CalendarAction.tsx
@@ -17,17 +17,18 @@ type Props = {
   date: string
   onCancle: () => void
   onReserve: (message: string) => void
-  onEdit: (schedule: ProviderScheduleWithPos) => void
+  onEdit: (isEdit: boolean) => void
   onSubmit: (schedule: ScheduleAddFormData) => void
 }
+
 export default function CalendarAction({
   type,
   user,
   schedule,
   date,
+  onEdit,
   onCancle,
   onReserve,
-  onEdit,
   onSubmit
 }: Props) {
   const [cookie] = useCookies(['AccessToken'])
@@ -64,13 +65,22 @@ export default function CalendarAction({
       })
   }
 
+  const handleEdit = (
+    schedule: ProviderScheduleWithPos & {
+      imgFile?: File
+    }
+  ) => {
+    console.info('HANDLE SCHEDULE', schedule)
+    onEdit(true)
+  }
+
   return (
     <>
       {type === 'add' && user == 'admin' && (
         <AddForm onCancle={onCancle} onSubmit={onSubmit} date={date} />
       )}
       {type === 'edit' && user == 'admin' && (
-        <EditForm onCancle={onCancle} onEdit={onEdit} schedule={schedule!} />
+        <EditForm onCancle={onCancle} onEdit={handleEdit} schedule={schedule!} />
       )}
       {type === 'reserve' && (
         <ReserveForm

--- a/src/components/calendar/CalendarAction.tsx
+++ b/src/components/calendar/CalendarAction.tsx
@@ -9,6 +9,7 @@ import { addSchedule } from '@/api/schedule/user'
 import dayjs from 'dayjs'
 import useUser from '@/hooks/user'
 import { DATE_REQEUST_FORMAT } from '@/constants'
+import api from '@/api'
 
 type Props = {
   type: 'add' | 'edit' | 'reserve'
@@ -70,8 +71,48 @@ export default function CalendarAction({
       imgFile?: File
     }
   ) => {
-    console.info('HANDLE SCHEDULE', schedule)
-    onEdit(true)
+    const formData = new FormData()
+    if (schedule.imgFile) formData.append('file', schedule.imgFile as Blob)
+    formData.append(
+      'dto',
+      new Blob(
+        [
+          JSON.stringify({
+            title: schedule.title,
+            scheduleStart: dayjs(schedule.startDate).format(DATE_REQEUST_FORMAT),
+            scheduleEnd: dayjs(schedule.endDate).format(DATE_REQEUST_FORMAT),
+            description: schedule.description
+          })
+        ],
+        {
+          type: 'application/json'
+        }
+      )
+    )
+
+    console.info({
+      id: schedule.id,
+      title: schedule.title,
+      description: schedule.description,
+      scheduleStart: dayjs(schedule.startDate).format(DATE_REQEUST_FORMAT),
+      scheduleEnd: dayjs(schedule.endDate).format(DATE_REQEUST_FORMAT)
+    })
+
+    api(`/admin/schedule/update/${schedule.id}`, {
+      method: 'POST',
+      data: formData,
+      headers: {
+        'Content-Type': 'multipart/form-data',
+        Authorization: cookie.AccessToken
+      }
+    })
+      .then(() => {
+        onEdit(true)
+      })
+      .catch((err) => {
+        console.error(err)
+        onEdit(false)
+      })
   }
 
   return (

--- a/src/components/calendar/CalendarAction.tsx
+++ b/src/components/calendar/CalendarAction.tsx
@@ -54,12 +54,14 @@ export default function CalendarAction({
   const handleReserve = (schedule: ProviderScheduleWithPos, selectDate: string) => {
     reserveMutation
       .mutateAsync({
-        adminId: schedule.id,
+        adminId: schedule.userId,
         selectDate: dayjs(selectDate).format(DATE_REQEUST_FORMAT)
       })
       .then((isReflected) => {
-        if (isReflected) onReserve('행사가 추가되었습니다.')
-        else onReserve('행사 추가에 실패했습니다.')
+        if (isReflected) {
+          queryClient.invalidateQueries(['schedule'])
+          onReserve('행사가 추가되었습니다.')
+        } else onReserve('행사 추가에 실패했습니다.')
       })
       .catch(() => {
         onReserve('행사 추가에 실패했습니다.')
@@ -89,14 +91,6 @@ export default function CalendarAction({
         }
       )
     )
-
-    console.info({
-      id: schedule.id,
-      title: schedule.title,
-      description: schedule.description,
-      scheduleStart: dayjs(schedule.startDate).format(DATE_REQEUST_FORMAT),
-      scheduleEnd: dayjs(schedule.endDate).format(DATE_REQEUST_FORMAT)
-    })
 
     api(`/admin/schedule/update/${schedule.id}`, {
       method: 'POST',

--- a/src/components/calendar/CalendarFrame.tsx
+++ b/src/components/calendar/CalendarFrame.tsx
@@ -3,14 +3,17 @@ import useSchedule from '@/hooks/schedule'
 import MonthlyCalendar from '@/components/calendar/MonthlyCalendar'
 import CalendarSwiper from '@/components/calendar/CalendarSwiper'
 import CheerUpLoading from '@/components/ui/CheerUpLoading'
+import useUser from '@/hooks/user'
 
 export default function CalendarFrame() {
-  const { isFetching } = useSchedule()
+  const { getUserInfo } = useUser()
+  const user = getUserInfo()
+  const { isFetching, isLoading } = useSchedule(user.id ? user.id : '')
 
   return (
     <>
       <CalendarSwiper />
-      {isFetching && (
+      {(isFetching || isLoading) && (
         <div className='fixed flex flex-col w-full h-full left-0 top-0 bg-purple-50 z-[99999] justify-center items-center opacity-90 overflow-hidden'>
           <div className='text-black  text-7xl font-extrabold opacity-80 mb-12'>
             데이터를 가져오고 있습니다!

--- a/src/components/calendar/CalendarFrame.tsx
+++ b/src/components/calendar/CalendarFrame.tsx
@@ -14,7 +14,7 @@ export default function CalendarFrame() {
     <>
       <CalendarSwiper />
       {(isFetching || isLoading) && (
-        <div className='fixed flex flex-col w-full h-full left-0 top-0 bg-purple-50 z-[99999] justify-center items-center opacity-90 overflow-hidden'>
+        <div className='fixed flex flex-col w-full h-full left-0 top-0 bg-purple-50 z-[9999] justify-center items-center opacity-90 overflow-hidden'>
           <div className='text-black  text-7xl font-extrabold opacity-80 mb-12'>
             데이터를 가져오고 있습니다!
           </div>

--- a/src/components/calendar/CalendarSwiper.tsx
+++ b/src/components/calendar/CalendarSwiper.tsx
@@ -9,8 +9,11 @@ import { CALENDAR_TAG_ID, DATE_ROUTE_FORMAT } from '@/constants'
 import Button from '@/components/ui/Button'
 import HighlightInformation from '@/components/calendar/HighlightInformation'
 import ArrowButton, { DirectionType } from '@/components/ui/ArrowButton'
+import useUser from '@/hooks/user'
 
 export default function CalendarSwiper() {
+  const { getUserInfo } = useUser()
+  const user = getUserInfo()
   const location = useLocation()
   const { isFetching } = useSchedule()
   const { year, month } = useSchedule()
@@ -21,7 +24,6 @@ export default function CalendarSwiper() {
     (direction: DirectionType) => {
       //  todo 비정상적 주소 이동 어떻게 처리할지 정하기
       if (!year || !month) return alert('비정상적인 접근입니다.')
-
       const route = location.pathname.split(`/${year}`)[0]
       const path = swipeCalendar(direction, {
         year,
@@ -43,13 +45,16 @@ export default function CalendarSwiper() {
 
   // todo max width를 캘린더와 동일하게 맞추기
   return (
-    <div className='flex items-center  justify-between mt-2 mb-14  mx-auto'>
-      <div className='min-w-[33.33%] basis-[33.33%] relative'>
-        <HighlightInformation />
-      </div>
+    <div className='flex items-center  justify-between mt-2 mb-4  mx-auto'>
+      {user.role === 'USER' && (
+        <div className='min-w-[33.33%] basis-[33.33%] relative'>
+          <HighlightInformation />
+        </div>
+      )}
+
       <div className='flex items-center basis-[33.33%]'>
         <ArrowButton disabled={isFetching} direction='left' onClick={handleArrowBtn} />
-        <h1 className='text-2xl mx-2 text-main'>
+        <h1 className='text-2xl mx-2 text-main whitespace-nowrap'>
           <span className='mr-2'>
             <strong className='text-4xl'>{year}</strong>년
           </span>
@@ -58,9 +63,14 @@ export default function CalendarSwiper() {
           </span>
         </h1>
         <ArrowButton disabled={isFetching} direction='right' onClick={handleArrowBtn} />
+        <Button
+          className='ml-2 mt-auto  min-w-[50px]'
+          size='sm'
+          text='오늘'
+          onClick={navagateToCurrentDate}
+        />
       </div>
       <div className='flex basis-auto'>
-        <Button className='mr-2' text='오늘' onClick={navagateToCurrentDate} />
         <Button className='mr-2' text='월간' onClick={navagateToCurrentDate} />
         <Button text='연간' />
       </div>

--- a/src/components/calendar/CalendarSwiper.tsx
+++ b/src/components/calendar/CalendarSwiper.tsx
@@ -45,14 +45,9 @@ export default function CalendarSwiper() {
 
   // todo max width를 캘린더와 동일하게 맞추기
   return (
-    <div className='flex items-center  justify-between mt-2 mb-4  mx-auto'>
-      {user.role === 'USER' && (
-        <div className='min-w-[33.33%] basis-[33.33%] relative'>
-          <HighlightInformation />
-        </div>
-      )}
-
-      <div className='flex items-center basis-[33.33%]'>
+    <div className='flex items-center justify-center w-full max-w-[1420px] mt-2 mb-4 mx-auto'>
+      <div className='w-[33.33%] flex-wrap'>{user.role === 'USER' && <HighlightInformation />}</div>
+      <div className='flex flex-1 justify-center'>
         <ArrowButton disabled={isFetching} direction='left' onClick={handleArrowBtn} />
         <h1 className='text-2xl mx-2 text-main whitespace-nowrap'>
           <span className='mr-2'>
@@ -70,7 +65,7 @@ export default function CalendarSwiper() {
           onClick={navagateToCurrentDate}
         />
       </div>
-      <div className='flex basis-auto'>
+      <div className='flex w-[33.33%] justify-end'>
         <Button className='mr-2' text='월간' onClick={navagateToCurrentDate} />
         <Button text='연간' />
       </div>

--- a/src/components/calendar/Daily.tsx
+++ b/src/components/calendar/Daily.tsx
@@ -71,8 +71,9 @@ export default function Daily({ daily }: Props) {
   }, [])
 
   // * 수정 모달에서 수정 버튼을 누르면 실행됩니다.
-  const handleEdit = (schedule: ProviderScheduleWithPos) => {
-    alert(`${schedule.title} 공연을 ${schedule.startDate} ~ ${schedule.endDate}로 수정 하셨습니다.`)
+  const handleEdit = (isEdit: boolean) => {
+    if (isEdit) alert('수정되었습니다.')
+    else alert('수정에 실패했습니다.')
     setOpenPortal(false)
   }
 

--- a/src/components/calendar/Daily.tsx
+++ b/src/components/calendar/Daily.tsx
@@ -13,7 +13,6 @@ import DailyDetail from '@/components/calendar/DailyDetail'
 import ModalPortal from '@/components/ui/ModalPortal'
 import CalendarAction from '@/components/calendar/CalendarAction'
 import { DATE_FORMAT } from '@/constants'
-import { ScheduleAddFormData } from '@/components/calendar/AddForm'
 
 type Props = {
   daily: string[]
@@ -83,15 +82,8 @@ export default function Daily({ daily }: Props) {
   }
 
   // * 공연 추가 모달에서 새로운 공연을 추가하면 실행됩니다.
-  const handleSubmitSchedule = (schedule: ScheduleAddFormData) => {
-    alert(
-      schedule.title +
-        ' 공연을 ' +
-        schedule.startDate +
-        ' ~ ' +
-        schedule.endDate +
-        '로 등록 하셨습니다.'
-    )
+  const handleSubmitSchedule = (message: string) => {
+    alert(message)
     setOpenPortal(false)
   }
 

--- a/src/components/calendar/DailyDetail.tsx
+++ b/src/components/calendar/DailyDetail.tsx
@@ -11,7 +11,6 @@ type Props = {
 }
 export default function DailyDetail({ date, onClick }: Props) {
   const { adminSchedule, reservedList, isFetching } = useSchedule()
-
   const [scheduleWithPos, setScheduleWithPos] = useState<ProviderScheduleWithPos[]>([])
 
   useEffect(() => {

--- a/src/components/calendar/DailySchedule.tsx
+++ b/src/components/calendar/DailySchedule.tsx
@@ -31,7 +31,7 @@ export default function DailySchedule({
   let bgStyle = 'bg-main hover:bg-[#4619a5]'
   if (typeof reservedList !== 'undefined') {
     reservedList.forEach((r) => {
-      if (r.id === schedule.id) {
+      if (r.scheduleId === schedule.id) {
         bgStyle = bgByProgress[r.progress]
       }
     })

--- a/src/components/calendar/DailySchedule.tsx
+++ b/src/components/calendar/DailySchedule.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import dayjs from 'dayjs'
 import type { ProviderScheduleWithPos } from '@/utils/calendar'
 import { ProviderReservedList } from '@/models/schedule'
-// import useSchedule from '@/hooks/schedule'
 
 type Props = {
   schedule: ProviderScheduleWithPos
@@ -32,7 +31,7 @@ export default function DailySchedule({
   let bgStyle = 'bg-main hover:bg-[#4619a5]'
   if (typeof reservedList !== 'undefined') {
     reservedList.forEach((r) => {
-      if (r.title === schedule.title) {
+      if (r.id === schedule.id) {
         bgStyle = bgByProgress[r.progress]
       }
     })
@@ -58,7 +57,7 @@ export default function DailySchedule({
             <img
               src={schedule.profileImage}
               alt={schedule.fullName}
-              className='schedule-cell absolute w-5 h-5 z-40'
+              className='schedule-cell absolute max-w-5 max-h-5 aspect-square object-cover z-40'
             />
             <div
               className={`schedule-cell w-full ${

--- a/src/components/calendar/EditForm.tsx
+++ b/src/components/calendar/EditForm.tsx
@@ -5,9 +5,12 @@ import EditFormInformation from './EditFormInformation'
 
 type Props = {
   schedule: ProviderScheduleWithPos
-
   onCancle: () => void
-  onEdit: (schedule: ProviderScheduleWithPos) => void
+  onEdit: (
+    schedule: ProviderScheduleWithPos & {
+      imgFile?: File
+    }
+  ) => void
 }
 
 export default function EditForm({ schedule, onCancle, onEdit }: Props) {

--- a/src/components/calendar/EditForm.tsx
+++ b/src/components/calendar/EditForm.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { ProviderScheduleWithPos } from '@/utils/calendar'
-
 import EditFormInformation from './EditFormInformation'
 
 type Props = {

--- a/src/components/calendar/EditFormInformation.tsx
+++ b/src/components/calendar/EditFormInformation.tsx
@@ -48,8 +48,8 @@ export default function EditFormInformation({ schedule, onEdit, onCancle }: Prop
     // todo : validation 체크하기
     const newSchedule = {
       ...schedule,
-      startDate,
-      endDate,
+      startDate: startDate ? startDate : schedule.startDate,
+      endDate: endDate ? endDate : schedule.endDate,
       title,
       description,
       imgFile

--- a/src/components/calendar/EditFormInformation.tsx
+++ b/src/components/calendar/EditFormInformation.tsx
@@ -8,21 +8,26 @@ import Button from '@/components/ui/Button'
 type Props = {
   schedule: ProviderScheduleWithPos
   onCancle: () => void
-  onEdit: (schedule: ProviderScheduleWithPos) => unknown
+  onEdit: (
+    schedule: ProviderScheduleWithPos & {
+      imgFile?: File
+    }
+  ) => unknown
 }
 
 export default function EditFormInformation({ schedule, onEdit, onCancle }: Props) {
   const [imgSrc, setImgSrc] = useState('')
+  const [imgFile, setImgFile] = useState<File>()
   const date = dayjs(new Date()).format(DATE_FORMAT)
   const [startDate, setStartDate] = useState('')
   const [endDate, setEndDate] = useState('')
   const [title, setTitle] = useState(schedule.title)
-  const [description, setDescription] = useState('설명란은 아직 없습니다!')
+  const [description, setDescription] = useState(schedule.description)
   //이미지 미리보기
   const handleChangeFile = (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files
     if (files && files.length > 0) {
-      const file = files[0]
+      setImgFile(files[0])
       const reader = new FileReader()
       reader.onloadend = () => {
         const base64 = reader.result
@@ -35,7 +40,7 @@ export default function EditFormInformation({ schedule, onEdit, onCancle }: Prop
           setImgSrc(base64.toString())
         }
       }
-      reader.readAsDataURL(file)
+      reader.readAsDataURL(files[0])
     }
   }
 
@@ -47,21 +52,18 @@ export default function EditFormInformation({ schedule, onEdit, onCancle }: Prop
       endDate,
       title,
       description,
-      imgSrc
+      imgFile
     }
     onEdit(newSchedule)
   }
 
   return (
     <>
-      <p className='text-red-500 font-bold'>
-        * 더미데이터는 공연 이미지가 없습니다. profile 이미지로 대체합니다.
-      </p>
       <div className={'flex pb-4 justify-between items-end pt-4'}>
         <span draggable={true} className='text-xl font-bold flex-1'>
           이미지
         </span>
-        {imgSrc ? (
+        {imgFile ? (
           <Banner
             className='mr-2 p-2 bg-slate-300 rounded-xl'
             type='side'

--- a/src/components/calendar/EditFormInformation.tsx
+++ b/src/components/calendar/EditFormInformation.tsx
@@ -45,7 +45,6 @@ export default function EditFormInformation({ schedule, onEdit, onCancle }: Prop
   }
 
   const handleSubmit = () => {
-    // todo : validation 체크하기
     const newSchedule = {
       ...schedule,
       startDate: startDate ? startDate : schedule.startDate,
@@ -74,7 +73,7 @@ export default function EditFormInformation({ schedule, onEdit, onCancle }: Prop
           <Banner
             className='mr-2 p-2 bg-slate-300 rounded-xl'
             type='side'
-            src='/YeonganIdolLogoOrigin.svg'
+            src={schedule.image}
             alt='공연 이미지'
           />
         )}

--- a/src/components/calendar/HighlightInformation.tsx
+++ b/src/components/calendar/HighlightInformation.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 export default function HighlightInformation() {
   return (
-    <div className='flex text-[0.7rem] absolute top-0'>
+    <div className='flex text-[0.7rem] top-0'>
       <div className='flex items-center mr-[0.4rem]'>
         <div className='w-4 h-4 rounded-[4px] bg-main mr-[0.2rem]' />
         <p className='whitespace-nowrap'>행사 일정</p>

--- a/src/components/calendar/MonthlyCalendar.tsx
+++ b/src/components/calendar/MonthlyCalendar.tsx
@@ -17,10 +17,9 @@ export default function MonthlyCalendar() {
     <div className='w-full'>
       <div
         id={CALENDAR_TAG_ID}
-        className={`grid grid-cols-cal-w gap-1 grid-rows-cal-h-13
-       w-fit  m-auto overflow-x-hidden
-       transition-all duration-100 ease-in-out rounded-xl border-[4px] border-white
-       `}
+        className={
+          'grid grid-cols-cal-w gap-1 grid-rows-cal-h-13 w-fit m-auto overflow-x-hidden transition-all duration-100 ease-in-out rounded-xl border-[4px] border-white'
+        }
       >
         <Weeks />
         {isSuccess && <Daily daily={dailyIdx} />}

--- a/src/components/calendar/MonthlyCalendar.tsx
+++ b/src/components/calendar/MonthlyCalendar.tsx
@@ -14,16 +14,17 @@ export default function MonthlyCalendar() {
   const dailyIdx = caculateDailyIdx(year, month)
 
   return (
-    <div className='w-full'>
-      <div
-        id={CALENDAR_TAG_ID}
-        className={
-          'grid grid-cols-cal-w gap-1 grid-rows-cal-h-13 w-fit m-auto overflow-x-hidden transition-all duration-100 ease-in-out rounded-xl border-[4px] border-white'
-        }
-      >
-        <Weeks />
-        {isSuccess && <Daily daily={dailyIdx} />}
-      </div>
+    <div
+      id={CALENDAR_TAG_ID}
+      className={`grid grid-cols-cal-w gap-1 grid-rows-cal-h-13 m-auto overflow-x-hidden 
+transition-all duration-100 ease-in-out rounded-xl border-[4px] border-white`}
+    >
+      <Weeks />
+      {isSuccess ? (
+        <Daily daily={dailyIdx} />
+      ) : (
+        dailyIdx.map((d, i) => <div key={d + i} className='cell min-h-[100px] md:min-h-[120px]' />)
+      )}
     </div>
   )
 }

--- a/src/components/layouts/CalendarLayout.tsx
+++ b/src/components/layouts/CalendarLayout.tsx
@@ -6,7 +6,7 @@ export default function CalendarLayout() {
   const navigate = useNavigate()
   const { loggedIn } = useUser()
   useEffect(() => {
-    if (!loggedIn) navigate('/login/test')
+    if (!loggedIn) navigate('/login/api/test')
   }, [loggedIn, navigate])
 
   return (

--- a/src/components/layouts/MainLayout.tsx
+++ b/src/components/layouts/MainLayout.tsx
@@ -1,7 +1,20 @@
-import React from 'react'
-import { Outlet } from 'react-router-dom'
+import { DATE_ROUTE_FORMAT } from '@/constants'
+import useUser from '@/hooks/user'
+import dayjs from 'dayjs'
+import React, { useEffect } from 'react'
+import { Outlet, useNavigate } from 'react-router-dom'
 
 export default function MainLayout() {
+  const navigate = useNavigate()
+  const { getUserInfo, loggedIn } = useUser()
+
+  useEffect(() => {
+    if (loggedIn) {
+      navigate(`/calendar/${dayjs(new Date()).format(DATE_ROUTE_FORMAT)}`)
+      return
+    }
+    navigate('/login/api/test')
+  }, [getUserInfo, navigate, loggedIn])
   return (
     <main className='flex min-h-screen'>
       <Outlet />

--- a/src/components/layouts/MainLayout.tsx
+++ b/src/components/layouts/MainLayout.tsx
@@ -13,7 +13,7 @@ export default function MainLayout() {
       navigate(`/calendar/${dayjs(new Date()).format(DATE_ROUTE_FORMAT)}`)
       return
     }
-    // navigate('/login/api/test')
+    navigate('/login/api/test')
   }, [getUserInfo, navigate, loggedIn])
   return (
     <main className='flex min-h-screen'>

--- a/src/components/layouts/MainLayout.tsx
+++ b/src/components/layouts/MainLayout.tsx
@@ -13,7 +13,7 @@ export default function MainLayout() {
       navigate(`/calendar/${dayjs(new Date()).format(DATE_ROUTE_FORMAT)}`)
       return
     }
-    navigate('/login/api/test')
+    // navigate('/login/api/test')
   }, [getUserInfo, navigate, loggedIn])
   return (
     <main className='flex min-h-screen'>

--- a/src/components/layouts/ManagerLayout.tsx
+++ b/src/components/layouts/ManagerLayout.tsx
@@ -10,13 +10,13 @@ export default function ManagerLayout() {
   useEffect(() => {
     if (!loggedIn) {
       alert('로그인 후 이용해주세요')
-      navigate('/login/test')
+      navigate('/login/api/test')
       return
     }
     const user = getUserInfo()
     if (user.role !== 'ADMIN') {
       alert('관리자만 접근할 수 있는 페이지 입니다!')
-      navigate('/login/test')
+      navigate('/login/api/test')
       return
     }
   }, [getUserInfo, loggedIn, navigate])

--- a/src/components/layouts/UserLayout.tsx
+++ b/src/components/layouts/UserLayout.tsx
@@ -10,13 +10,13 @@ export default function ManagerLayout() {
   useEffect(() => {
     if (!loggedIn) {
       alert('로그인 후 이용해주세요')
-      navigate('/login/test')
+      navigate('/login/api/test')
       return
     }
     const user = getUserInfo()
     if (user.role !== 'USER') {
       alert('사용자만 접근할 수 있는 페이지 입니다!')
-      navigate('/login/test')
+      navigate('/login/api/test')
       return
     }
   }, [getUserInfo, loggedIn, navigate])

--- a/src/components/sidebar/Profile.tsx
+++ b/src/components/sidebar/Profile.tsx
@@ -29,7 +29,7 @@ export default function Profile({ user }: Props) {
           className='font-bold w-4/5 rounded-xl'
           onClick={() => {
             alert('임시로 페이지를 새로 고쳐 로그아웃합니다.')
-            window.location.href = '/login/test'
+            window.location.href = '/login/api/test'
           }}
         />
       </div>

--- a/src/components/sidebar/Profile.tsx
+++ b/src/components/sidebar/Profile.tsx
@@ -14,7 +14,7 @@ export default function Profile({ user }: Props) {
         <div className='text-center'>
           <h2 className='text-xl text-white font-bold'> {user.fullName}</h2>
           <Link
-            to='/user/edit'
+            to={`${user.role === 'ADMIN' ? '/manager' : '/user'}/edit`}
             className='inline-block bg-white px-3 rounded-xl font-bold text-[0.9rem] leading-6 mt-4'
           >
             수정

--- a/src/components/user/ReserveDetail.tsx
+++ b/src/components/user/ReserveDetail.tsx
@@ -25,8 +25,8 @@ export default function ReserveDetail({ user }: Props) {
       <div className='flex justify-center'>
         {isSuccess && data && (
           <>
-            <Ticket type='used' ticket={data?.usedTicket} />
-            <Ticket type='rest' ticket={data?.sizeOfTicket} />
+            <Ticket type='used' ticket={data?.getUserInfoDTO.usedTicket} />
+            <Ticket type='rest' ticket={data?.getUserInfoDTO.sizeOfTicket} />
           </>
         )}
       </div>

--- a/src/models/schedule.ts
+++ b/src/models/schedule.ts
@@ -14,14 +14,10 @@ export type ProviderSchedule = {
 
 export type ProviderReservedList = {
   id: string
-  userID: string
-  profileImage: string
-  fullName: string
-  role: string
-  sizeOfTicket: number
+  scheduleId: string
   reservedDate: string
   progress: 'WAITING' | 'ACCEPT' | 'REFUSE'
-  title: string
+  user: FanUser
 }
 
 export type AdminSchedule = {

--- a/src/models/schedule.ts
+++ b/src/models/schedule.ts
@@ -36,6 +36,7 @@ export type AdminSchedule = {
 }
 
 export type UserSchedule = {
+  id: string
   scheduleStart: string // reservedDate
   createdAt: string
   progress: 'WAITING' | 'ACCEPT' | 'REFUSE'

--- a/src/models/schedule.ts
+++ b/src/models/schedule.ts
@@ -25,6 +25,7 @@ export type ProviderReservedList = {
 }
 
 export type AdminSchedule = {
+  id: string
   createdAt: string
   description: string
   scheduleEnd: string

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -1,18 +1,16 @@
 import Banner from '@/components/Banner'
 import SideBar from '@/components/SideBar'
 import CalendarFrame from '@/components/calendar/CalendarFrame'
-// import useUser from '@/hooks/user'
 import React from 'react'
 
 export default function CalendarPage() {
-  // const { getUserInfo } = useUser()
-
   return (
     <div className='grid grid-cols-cal-frame-w'>
       <SideBar />
-      {/*  max-w-[1432px] px-[0.25rem]는 켈린더 최대 너비입니다. */}
-      <div className='mb-12 min-w-[760px] max-w-[1432px] px-[1.25rem]'>
-        <Banner className='py-4' src='/newjeans_ad.png' type='top' alt='newjeans banner' />
+      <div className='flex flex-col justify-center mb-12 min-w-[760px] px-[1.25rem]'>
+        <div className='max-w-[1420px] m-auto'>
+          <Banner className='py-4' src='/newjeans_ad.png' type='top' alt='newjeans banner' />
+        </div>
         <CalendarFrame />
       </div>
     </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,4 @@
 import React from 'react'
 export default function Home() {
-  return <div>Home(landing) page</div>
+  return <div />
 }

--- a/src/pages/Manager/ManagerEventAddEdit/index.tsx
+++ b/src/pages/Manager/ManagerEventAddEdit/index.tsx
@@ -4,8 +4,10 @@ import React from 'react'
 
 export default function ManagerEventAddEditPage() {
   return (
-    <div className='mb-12 min-w-[760px] max-w-[1432px] px-[1.25rem]'>
-      <Banner className='py-4' src='/newjeans_ad.png' type='top' alt='newjeans banner' />
+    <div className='flex flex-col justify-center mb-12 min-w-[760px] px-[1.25rem]'>
+      <div className='max-w-[1420px] m-auto'>
+        <Banner className='py-4' src='/newjeans_ad.png' type='top' alt='newjeans banner' />
+      </div>
       <CalendarFrame />
     </div>
   )

--- a/src/pages/Sample/Schedule.tsx
+++ b/src/pages/Sample/Schedule.tsx
@@ -55,6 +55,7 @@ export default function ScheduleAddTestPage() {
     <div className='grid grid-cols-cal-frame-w'>
       <SideBar />
       {/*  max-w-[1432px] px-[0.25rem]는 켈린더 최대 너비입니다. */}
+
       <div className='mb-12 min-w-[760px] max-w-[1432px] px-[1.25rem]'>
         <Banner className='py-4' src='/newjeans_ad.png' type='top' alt='newjeans banner' />
         <div>

--- a/src/pages/User/MyPage.tsx
+++ b/src/pages/User/MyPage.tsx
@@ -11,7 +11,7 @@ export default function MyPage() {
 
   if (fan.role !== 'USER') {
     alert('관리자는 접근할 수 없는 페이지입니다.')
-    navigate('/login/test')
+    navigate('/login/api/test')
     return
   }
 

--- a/src/utils/calendar.ts
+++ b/src/utils/calendar.ts
@@ -67,7 +67,6 @@ export function getProviderSchdule(
   )
 
   const restItem = filtetedSchedule.length > 2 ? filtetedSchedule.length - 2 : 0
-
   const providerSchedule: ProviderScheduleWithPos[] = Array(100).fill(null)
   filtetedSchedule
     .map((s) => {
@@ -83,15 +82,20 @@ export function getProviderSchdule(
       if (s.startDate === date && s.endDate === date) pos = 'start-end'
       return { ...s, pos, restItem }
     })
-    .forEach((s, i) => {
+    .forEach((s) => {
       // * 하루 전 스케줄과 오늘 스케줄을 비교해서 적절한 인덱스에 스케줄을 넣는다.
       const pi = prevSchedule.findIndex((ps) => ps.id === s.id)
       if (pi !== -1) {
-        if (pi == 2 && providerSchedule[i] === null) {
-          providerSchedule[pi] = { ...s, pos: 'start' }
-        } else {
-          providerSchedule[pi] = { ...s }
-        }
+        // if (pi == 2 && providerSchedule[pi] === null) {
+        //   if (providerSchedule[0] === null)
+        //     providerSchedule[0] = { ...s, pos: 'start', startDate: date }
+        //   else {
+        //     providerSchedule[pi] = { ...s, pos: 'start', startDate: date }
+        //   }
+        // } else {
+        providerSchedule[pi] = { ...s }
+        // }
+        return
       } else {
         for (let j = 0; j < providerSchedule.length; j++) {
           if (providerSchedule[j] === null) {
@@ -101,6 +105,5 @@ export function getProviderSchdule(
         }
       }
     })
-
   return providerSchedule.filter((s) => s !== null)
 }


### PR DESCRIPTION
# 요약

캘린더 페이지 추가, 수정, 예약 기능 API와 연동

전체 레이아웃 조정

# 참고 이미지

1. 전체 레이아웃 조정

![화면 캡처 2023-08-08 033116](https://github.com/MINI-FASTCAMPUS5/scheduler-front/assets/73880776/6a7252af-d176-458d-a563-26e30b4f362c)

2. 사용자 예약

![화면 캡처 2023-08-08 042118](https://github.com/MINI-FASTCAMPUS5/scheduler-front/assets/73880776/7bb9de2f-aed3-4e51-a91e-df24520c13ab)

4. 행사 추가

![화면 캡처 2023-08-08 042106](https://github.com/MINI-FASTCAMPUS5/scheduler-front/assets/73880776/c5bfc476-213c-4ecf-8221-4c7e784d9105)

6. 행사 수정

![화면 캡처 2023-08-08 042059](https://github.com/MINI-FASTCAMPUS5/scheduler-front/assets/73880776/f6857384-9ba2-4aa9-ae5e-a152a09dc0a7)


